### PR TITLE
feat(browser): introduce `toMatchScreenshot` for Visual Regression Testing

### DIFF
--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -2,6 +2,8 @@ import { SerializedConfig } from 'vitest'
 import { ARIARole } from './aria-role.js'
 import {} from './matchers.js'
 
+export * from './screenshot.js'
+
 export type BufferEncoding =
   | 'ascii'
   | 'utf8'
@@ -23,25 +25,6 @@ export interface FsOptions {
 
 export interface CDPSession {
   // methods are defined by the provider type augmentation
-}
-
-export interface ScreenshotOptions {
-  element?: Element | Locator
-  /**
-   * Path relative to the current test file.
-   * @default `__screenshots__/${testFileName}/${testName}.png`
-   */
-  path?: string
-  /**
-   * Will also return the base64 encoded screenshot alongside the path.
-   */
-  base64?: boolean
-  /**
-   * Keep the screenshot on the file system. If file is not saved,
-   * `page.screenshot` always returns `base64` screenshot.
-   * @default true
-   */
-  save?: boolean
 }
 
 export interface BrowserCommands {

--- a/packages/browser/jest-dom.d.ts
+++ b/packages/browser/jest-dom.d.ts
@@ -1,6 +1,7 @@
 // Disable automatic exports.
 
 import { ARIARole } from './aria-role.ts'
+import { Comparators, ScreenshotMatcherOptions } from './screenshot.js'
 
 export interface TestingLibraryMatchers<E, R> {
   /**
@@ -627,4 +628,12 @@ export interface TestingLibraryMatchers<E, R> {
    * @see https://vitest.dev/guide/browser/assertion-api#tohaveselection
    */
   toHaveSelection(selection?: string): R
+
+  toMatchScreenshot<Comparator extends keyof Comparators>(
+    name?: string,
+    options?: ScreenshotMatcherOptions<Comparator>,
+  ): Promise<R>
+  toMatchScreenshot<Comparator extends keyof Comparators>(
+    options?: ScreenshotMatcherOptions<Comparator>,
+  ): Promise<R>
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -93,11 +93,14 @@
     "@vitest/mocker": "workspace:*",
     "@vitest/utils": "workspace:*",
     "magic-string": "catalog:",
+    "pixelmatch": "7.1.0",
+    "pngjs": "^7.0.0",
     "sirv": "catalog:",
     "tinyrainbow": "catalog:",
     "ws": "catalog:"
   },
   "devDependencies": {
+    "@types/pngjs": "^6.0.5",
     "@types/ws": "catalog:",
     "@vitest/runner": "workspace:*",
     "@vitest/ui": "workspace:*",

--- a/packages/browser/screenshot.d.ts
+++ b/packages/browser/screenshot.d.ts
@@ -1,0 +1,62 @@
+import type pm from 'pixelmatch'
+
+export interface ScreenshotOptions {
+  element?: Element | Locator
+  /**
+   * Path relative to the current test file.
+   * @default `__screenshots__/${testFileName}/${testName}.png`
+   */
+  path?: string
+  /**
+   * Will also return the base64 encoded screenshot alongside the path.
+   */
+  base64?: boolean
+  /**
+   * Keep the screenshot on the file system. If file is not saved,
+   * `page.screenshot` always returns `base64` screenshot.
+   * @default true
+   */
+  save?: boolean
+}
+
+export type TypedArray = Buffer<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike>
+export type Promisable<T> = T | Promise<T>
+
+export type Comparator<Options extends Record<string, unknown>> = (reference: {
+  metadata: { height: number; width: number }
+  data: TypedArray
+}, actual: {
+  metadata: { height: number; width: number }
+  data: TypedArray
+}, options: {
+  /**
+   * Allows the comparator to create a diff image.
+   *
+   * Note that the comparator might choose to ignore the flag, so a diff image is not guaranteed.
+   */
+  createDiff: boolean
+} & Options) => Promisable<{ pass: boolean; diff: TypedArray | null }>
+
+export interface Comparators {
+  pixelmatch: {
+    // @todo percentage-based threshold
+    options: NonNullable<Parameters<typeof pm>['5']>;
+    instance: Comparator<Comparators['pixelmatch']['options']>
+  }
+}
+
+export interface ScreenshotMatcherOptions<Comparator extends keyof Comparators = keyof Comparators> {
+  comparatorOptions: {
+    name: Comparator
+  } & Comparators[Comparator]['options']
+  screenshotOptions: Omit<ScreenshotOptions, 'element' | 'base64' | 'save' | 'type'>
+  /**
+   * Time to wait until a stable screenshot is found.
+   *
+   * Setting this value to `0` disables the timeout, but if a stable screenshot
+   * can't be determined the process will not end.
+   *
+   * @default 5000
+   */
+  timeout?: number
+}

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -338,7 +338,7 @@ function convertToLocator(element: Element | Locator): Locator {
   return element
 }
 
-function convertToSelector(elementOrLocator: Element | Locator): string {
+export function convertToSelector(elementOrLocator: Element | Locator): string {
   if (!elementOrLocator) {
     throw new Error('Expected element or locator to be defined.')
   }

--- a/packages/browser/src/client/tester/expect/index.ts
+++ b/packages/browser/src/client/tester/expect/index.ts
@@ -22,6 +22,7 @@ import toHaveSelection from './toHaveSelection'
 import toHaveStyle from './toHaveStyle'
 import toHaveTextContent from './toHaveTextContent'
 import toHaveValue from './toHaveValue'
+import toMatchScreenshot from './toMatchScreenshot'
 
 export const matchers: MatchersObject = {
   toBeDisabled,
@@ -49,4 +50,5 @@ export const matchers: MatchersObject = {
   toBePartiallyChecked,
   toHaveRole,
   toHaveSelection,
+  toMatchScreenshot,
 }

--- a/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
+++ b/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
@@ -1,0 +1,83 @@
+import type { ScreenshotMatcherOptions } from '@vitest/browser/context'
+import type { AsyncExpectationResult, MatcherState } from '@vitest/expect'
+import type { ScreenshotMatcherArguments, ScreenshotMatcherOutput } from '../../../node/commands/screenshotMatcher'
+import type { Locator } from '../locators'
+import { deepMerge } from '@vitest/utils'
+import { ensureAwaited, getBrowserState } from '../../utils'
+import { convertToSelector } from '../context'
+import { getMessage } from './utils'
+
+const defaultOptions = {
+  comparatorOptions: {
+    name: 'pixelmatch',
+  },
+  screenshotOptions: {
+    animations: 'disabled',
+    caret: 'hide',
+    fullPage: false,
+    omitBackground: false,
+    scale: 'css',
+  },
+} satisfies ScreenshotMatcherOptions<'pixelmatch'>
+
+export default async function toMatchScreenshot(
+  this: MatcherState,
+  actual: Locator,
+  nameOrOptions?: ScreenshotMatcherOptions | string,
+  options: ScreenshotMatcherOptions = typeof nameOrOptions === 'object'
+    ? nameOrOptions
+    : defaultOptions,
+): AsyncExpectationResult {
+  if (this.isNot) {
+    throw new Error('\'toMatchScreenshot\' cannot be used with "not"')
+  }
+
+  if (this.currentTestName === undefined) {
+    throw new Error('\'toMatchScreenshot\' cannot be used without test context')
+  }
+
+  // @todo add a counter after the name
+  const name
+    = typeof nameOrOptions === 'string' ? nameOrOptions : this.currentTestName
+
+  const result = await ensureAwaited(error =>
+    getBrowserState().commands.triggerCommand<ScreenshotMatcherOutput>(
+      '__vitest_screenshotMatcher',
+      [
+        name,
+        deepMerge<ScreenshotMatcherArguments[1]>(
+          {
+            element: convertToSelector(actual),
+            timeout: 5_000,
+          } satisfies Omit<
+            ScreenshotMatcherArguments[1],
+            'comparatorOptions' | 'screenshotOptions'
+          > as any,
+          defaultOptions,
+          options,
+        ),
+      ] satisfies ScreenshotMatcherArguments,
+      error,
+    ))
+
+  let message = ''
+
+  if (result.pass === false) {
+    message = getMessage(
+      this,
+      'toMatchScreenshot',
+      `${result.message}${result.reference ? '\nReference screenshot:' : ''}`,
+      result.reference,
+      result.actual ? 'Actual screenshot:' : '',
+      result.actual,
+    )
+
+    // @todo use annotate to log diff images: https://github.com/vitest-dev/vitest/pull/7953
+  }
+
+  return {
+    pass: result.pass,
+    message: () =>
+      message,
+  }
+}

--- a/packages/browser/src/node/commands/index.ts
+++ b/packages/browser/src/node/commands/index.ts
@@ -11,6 +11,7 @@ import {
 import { hover } from './hover'
 import { keyboard, keyboardCleanup } from './keyboard'
 import { screenshot } from './screenshot'
+import { screenshotMatcher } from './screenshotMatcher'
 import { selectOptions } from './select'
 import { tab } from './tab'
 import { type } from './type'
@@ -35,4 +36,5 @@ export default {
   __vitest_dragAndDrop: dragAndDrop as typeof dragAndDrop,
   __vitest_hover: hover as typeof hover,
   __vitest_cleanup: keyboardCleanup as typeof keyboardCleanup,
+  __vitest_screenshotMatcher: screenshotMatcher as typeof screenshotMatcher,
 }

--- a/packages/browser/src/node/commands/screenshot.ts
+++ b/packages/browser/src/node/commands/screenshot.ts
@@ -21,13 +21,12 @@ export const screenshot: BrowserCommand<[string, ScreenshotOptions]> = async (
     options.base64 = true
   }
 
-  const path = options.path
-    ? resolve(dirname(context.testPath), options.path)
-    : resolveScreenshotPath(
-        context.testPath,
-        name,
-        context.project.config,
-      )
+  const path = resolveScreenshotPath(
+    context.testPath,
+    name,
+    context.project.config,
+    options.path,
+  )
   const savePath = normalize(path)
   await mkdir(dirname(path), { recursive: true })
 
@@ -67,11 +66,15 @@ export const screenshot: BrowserCommand<[string, ScreenshotOptions]> = async (
   )
 }
 
-function resolveScreenshotPath(
+export function resolveScreenshotPath(
   testPath: string,
   name: string,
   config: ResolvedConfig,
-) {
+  customPath: string | undefined,
+): string {
+  if (customPath) {
+    return resolve(dirname(testPath), customPath)
+  }
   const dir = dirname(testPath)
   const base = basename(testPath)
   if (config.browser.screenshotDirectory) {

--- a/packages/browser/src/node/commands/screenshotMatcher/codecs/index.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/codecs/index.ts
@@ -1,0 +1,13 @@
+import png from './png'
+
+export function getCodec(type: 'png'): typeof png
+
+export function getCodec(type: string) {
+  switch (type) {
+    case 'png':
+      return png
+
+    default:
+      throw new Error(`No codec found for type ${type}`)
+  }
+}

--- a/packages/browser/src/node/commands/screenshotMatcher/codecs/png.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/codecs/png.ts
@@ -1,0 +1,47 @@
+import type { Metadata, PackerOptions, ParserOptions } from 'pngjs'
+import type { Codec } from './utils'
+import { PNG } from 'pngjs'
+
+const codec: Codec<ParserOptions, Metadata, PackerOptions> = {
+  decode: (buffer, options) => {
+    const {
+      data,
+      alpha,
+      bpp,
+      color,
+      colorType,
+      depth,
+      height,
+      interlace,
+      palette,
+      width,
+    } = PNG.sync.read(Buffer.from(buffer), options)
+
+    return {
+      metadata: {
+        alpha,
+        bpp,
+        color,
+        colorType,
+        depth,
+        height,
+        interlace,
+        palette,
+        width,
+      },
+      data,
+    }
+  },
+  encode: ({ data, metadata: { height, width } }, options) => {
+    const png = new PNG({
+      height,
+      width,
+    })
+
+    png.data = Buffer.from(data)
+
+    return PNG.sync.write(png, options)
+  },
+}
+
+export default codec

--- a/packages/browser/src/node/commands/screenshotMatcher/codecs/utils.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/codecs/utils.ts
@@ -1,0 +1,21 @@
+import type { Comparator, Promisable, TypedArray } from '../../../../../screenshot'
+
+type BaseMetadata = Parameters<Comparator<any>>[0]['metadata']
+
+export interface Codec<
+  DecoderOptions extends object,
+  DecoderMetadata extends object,
+  EncoderOptions extends object,
+> {
+  decode: (
+    buffer: TypedArray,
+    options: DecoderOptions
+  ) => Promisable<{
+    data: TypedArray
+    metadata: DecoderMetadata & BaseMetadata
+  }>
+  encode: (
+    image: { data: TypedArray; metadata: BaseMetadata },
+    options: EncoderOptions
+  ) => Promisable<TypedArray>
+}

--- a/packages/browser/src/node/commands/screenshotMatcher/comparators/index.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/comparators/index.ts
@@ -1,0 +1,31 @@
+import type { Comparator, Comparators } from '../../../../../screenshot'
+import { pixelmatch } from './pixelmatch'
+
+function guard<C extends Comparator<any>>(comparator: C): C {
+  return ((reference, actual, options) => {
+    if (reference.metadata.height !== actual.metadata.height || reference.metadata.width !== actual.metadata.width) {
+      return {
+        pass: false,
+        diff: null,
+      }
+    }
+
+    return comparator(reference, actual, options)
+  }) as C
+}
+
+const comparators = new Map(Object.entries({
+  pixelmatch,
+} satisfies {
+  [k in keyof Comparators]: Comparators[k]['instance']
+}))
+
+export function getComparator<Comparator extends keyof Comparators>(
+  comparator: Comparator,
+): Comparators[Comparator]['instance'] {
+  if (comparators.has(comparator)) {
+    return guard(comparators.get(comparator)!)
+  }
+
+  throw new Error(`Unrecognized comparator ${comparator}`)
+}

--- a/packages/browser/src/node/commands/screenshotMatcher/comparators/pixelmatch.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/comparators/pixelmatch.ts
@@ -1,0 +1,26 @@
+import type { Comparators } from '../../../../../screenshot'
+import pm from 'pixelmatch'
+
+export const pixelmatch: Comparators['pixelmatch']['instance'] = (
+  reference,
+  actual,
+  { createDiff, ...options },
+) => {
+  const diffBuffer = createDiff
+    ? new Uint8Array(reference.data.length)
+    : undefined
+
+  const result = pm(
+    reference.data,
+    actual.data,
+    diffBuffer,
+    reference.metadata.width,
+    reference.metadata.height,
+    options,
+  )
+
+  return {
+    pass: result > 0,
+    diff: diffBuffer ?? null,
+  }
+}

--- a/packages/browser/src/node/commands/screenshotMatcher/index.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/index.ts
@@ -1,0 +1,312 @@
+import type { Comparators, ScreenshotMatcherOptions, TypedArray } from '@vitest/browser/context'
+import type { BrowserCommand, BrowserCommandContext } from 'vitest/node'
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, normalize, resolve } from 'node:path'
+import { getSafeTimers } from '@vitest/utils'
+import { resolveScreenshotPath, screenshot } from '../screenshot'
+import { getCodec } from './codecs'
+import { getComparator } from './comparators'
+
+type Codec = ReturnType<typeof getCodec>
+type Comparator = ReturnType<typeof getComparator>
+
+export type ScreenshotMatcherArguments<
+  Comparator extends keyof Comparators = keyof Comparators,
+> = [name: string, options: Required<ScreenshotMatcherOptions<Comparator>> & { element: string }]
+export type ScreenshotMatcherOutput = Promise<
+  {
+    pass: false
+    reference: string | null
+    actual: string | null
+    diff: string | null
+    message: string
+  } |
+  { pass: true }
+>
+
+export const screenshotMatcher: BrowserCommand<
+  ScreenshotMatcherArguments
+> = async (context, name, {
+  comparatorOptions,
+  screenshotOptions,
+  element,
+  timeout,
+}): ScreenshotMatcherOutput => {
+  if (!context.testPath) {
+    throw new Error(`Cannot compare screenshots without a test path`)
+  }
+
+  // when more codecs will be available, allow `type` in `screenshotOptions`
+  const screenshotType = 'png'
+
+  const codec = getCodec(screenshotType)
+  const comparator = getComparator(comparatorOptions.name)
+
+  // @todo check if this is the correct path
+  const referencePath = normalize(resolveScreenshotPath(
+    context.testPath,
+    name,
+    context.project.config,
+    screenshotOptions.path,
+  ))
+  const hasReference = await access(referencePath).then(() => true).catch(() => false)
+  const reference = hasReference ? await codec.decode(await readFile(referencePath), {}) : null
+
+  const abortController = new AbortController()
+  const stableScreenshot = getStableScreenshots({
+    codec,
+    comparator,
+    comparatorOptions,
+    context,
+    element,
+    name,
+    reference,
+    screenshotOptions,
+    signal: abortController.signal,
+  })
+
+  const value = await (
+    timeout === 0
+      ? stableScreenshot
+      : Promise.race([
+          stableScreenshot,
+          asyncTimeout(timeout).finally(() => { abortController.abort() }),
+        ])
+  )
+
+  // case #01
+  //  - impossible to get a stable screenshot to compare against
+  //  - fail
+  if (value === null || value.actual === null) {
+    return {
+      pass: false,
+      reference: hasReference ? referencePath : null,
+      actual: null,
+      diff: null,
+      message: `It was impossible to get a stable screenshot in ${timeout}ms`,
+    }
+  }
+
+  // if there's no reference or if we want to update snapshots, we have to finish the comparison early
+  if (reference === null || context.project.config.snapshotOptions.updateSnapshot !== 'none') {
+    await writeScreenshot(referencePath, await codec.encode(value.actual, {}))
+
+    // case #02
+    //  - got a stable screenshot, but there is no reference and we don't want to update screenshots
+    //  - fail
+    if (
+      context.project.config.snapshotOptions.updateSnapshot === 'none'
+    ) {
+      return {
+        pass: false,
+        reference: referencePath,
+        actual: null,
+        diff: null,
+        message: 'Created reference screenshot while running this test',
+      }
+    }
+
+    // case #03
+    //  - got a stable screenshot, there is no reference, but we want to update screenshots
+    //  - pass
+    return {
+      pass: true,
+    }
+  }
+
+  // case #04
+  //  - got a stable screenshot with no retries and there's a reference
+  //  - pass
+  if (hasReference && value.retries === 0) {
+    return {
+      pass: true,
+    }
+  }
+
+  const finalResult = await comparator(reference, value.actual, { createDiff: true, ...comparatorOptions })
+
+  const diffBase = '/tmp/todo/' // @todo
+  let diffPath: string | null = null
+
+  if (finalResult.pass === false && finalResult.diff !== null) {
+    const diff = await codec.encode(
+      {
+        data: finalResult.diff,
+        metadata: {
+          height: reference.metadata.height,
+          width: reference.metadata.width,
+        },
+      },
+      {},
+    )
+
+    diffPath = resolve(diffBase, `todo.diff.${screenshotType}`) // @todo
+
+    await writeScreenshot(diffPath, diff)
+  }
+
+  // case #05
+  //  - reference matches stable screenshot
+  //  - pass
+  if (finalResult.pass === true) {
+    return {
+      pass: true,
+    }
+  }
+
+  const actualPath = resolve(diffBase, `todo.actual.${screenshotType}`) // @todo
+  const actual = await codec.encode(value.actual, {})
+
+  await writeScreenshot(actualPath, actual)
+
+  // case #06
+  //  - fallback, reference does NOT matches stable screenshot
+  //  - fail
+  return {
+    pass: false,
+    reference: referencePath,
+    actual: actualPath,
+    diff: diffPath,
+    message: 'Expected the element to match the reference screenshot',
+  }
+}
+
+async function writeScreenshot(path: string, image: TypedArray) {
+  try {
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, image)
+  }
+  catch {
+    throw new Error('Couldn\'t write file to fs')
+  }
+}
+
+/**
+ * Takes screenshots repeatedly until the page reaches a visually stable state.
+ *
+ * This function compares consecutive screenshots and continues taking new ones
+ * until two consecutive screenshots match according to the provided comparator.
+ *
+ * The process works as follows:
+ *
+ * 1. Uses as baseline an optional reference screenshot or takes a new screenshot
+ * 2. Takes a screenshot and compares with baseline
+ * 3. If they match, the page is considered stable and the function returns
+ * 4. If they don't match, it continues with the newer screenshot as the baseline
+ * 5. Repeats until stability is achieved or the operation is aborted
+ *
+ * @returns `Promise` resolving to an object containing the retry count and
+ * final screenshot
+ */
+async function getStableScreenshots({
+  codec,
+  context,
+  comparator,
+  comparatorOptions,
+  element,
+  name,
+  reference,
+  screenshotOptions,
+  signal,
+}: {
+  codec: Codec
+  comparator: Comparator
+  comparatorOptions: ScreenshotMatcherOptions['comparatorOptions']
+  context: BrowserCommandContext
+  element: string
+  name: string
+  reference: ReturnType<Codec['decode']> | null
+  screenshotOptions: ScreenshotMatcherOptions['screenshotOptions']
+  signal: AbortSignal
+}) {
+  const screenshotArgument = {
+    codec,
+    context,
+    element,
+    name,
+    screenshotOptions,
+  } satisfies Parameters<typeof takeScreenshot>[0]
+
+  let retries = 0
+
+  let decodedBaseline = reference
+
+  while (signal.aborted === false) {
+    if (decodedBaseline === null) {
+      decodedBaseline = takeScreenshot(screenshotArgument)
+    }
+
+    const [image1, image2] = await Promise.all([
+      decodedBaseline,
+      takeScreenshot(screenshotArgument),
+    ])
+
+    const comparatorResult = (await comparator(
+      image1,
+      image2,
+      { ...comparatorOptions, createDiff: false },
+    )).pass
+
+    decodedBaseline = image2
+
+    if (comparatorResult) {
+      break
+    }
+
+    retries += 1
+  }
+
+  return {
+    retries,
+    actual: await decodedBaseline,
+  }
+}
+
+/**
+ * Takes a screenshot and decodes it using the provided codec.
+ *
+ * The screenshot is taken as a base64 string and then decoded into the format
+ * expected by the comparator.
+ *
+ * @returns `Promise` resolving to the decoded screenshot data
+ */
+function takeScreenshot({
+  codec,
+  context,
+  element,
+  name,
+  screenshotOptions,
+}: {
+  codec: Codec
+  context: BrowserCommandContext
+  element: string
+  name: string
+  screenshotOptions: ScreenshotMatcherOptions['screenshotOptions']
+}) {
+  return (screenshot(
+    context,
+    name,
+    { ...screenshotOptions, save: false, element },
+  ) as Promise<string>)
+    .then(
+      (data: string) => codec.decode(Buffer.from(data, 'base64'), {}),
+    )
+}
+
+/**
+ * Creates a promise that resolves to `null` after the specified timeout.
+ * If the timeout is `0`, the promise resolves immediately.
+ *
+ * @param timeout - The delay in milliseconds before the promise resolves
+ * @returns `Promise` that resolves to `null` after the timeout
+ */
+function asyncTimeout(timeout: number): Promise<null> {
+  return new Promise((resolve) => {
+    if (timeout === 0) {
+      resolve(null)
+    }
+    else {
+      getSafeTimers().setTimeout(() => resolve(null), timeout)
+    }
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,12 @@ importers:
       magic-string:
         specifier: 'catalog:'
         version: 0.30.17
+      pixelmatch:
+        specifier: 7.1.0
+        version: 7.1.0
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       sirv:
         specifier: 'catalog:'
         version: 3.0.1
@@ -469,6 +475,9 @@ importers:
         specifier: 'catalog:'
         version: 8.18.2
     devDependencies:
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
@@ -3962,6 +3971,9 @@ packages:
 
   '@types/picomatch@4.0.0':
     resolution: {integrity: sha512-J1Bng+wlyEERWSgJQU1Pi0HObCLVcr994xT/M+1wcl/yNRTGBupsCxthgkdYG+GCOMaQH7iSVUY3LJVBBqG7MQ==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
 
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
@@ -7597,6 +7609,10 @@ packages:
     resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
     hasBin: true
 
+  pixelmatch@7.1.0:
+    resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
+    hasBin: true
+
   pkg-types@1.2.1:
     resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
 
@@ -7627,6 +7643,10 @@ packages:
   pngjs@6.0.0:
     resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
     engines: {node: '>=12.13.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   pnpm-workspace-yaml@0.3.1:
     resolution: {integrity: sha512-3nW5RLmREmZ8Pm8MbPsO2RM+99RRjYd25ynj3NV0cFsN7CcEl4sDFzgoFmSyduFwxFQ2Qbu3y2UdCh6HlyUOeA==}
@@ -11715,6 +11735,10 @@ snapshots:
 
   '@types/picomatch@4.0.0': {}
 
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 22.15.19
+
   '@types/prompts@2.4.9':
     dependencies:
       '@types/node': 22.15.19
@@ -11772,7 +11796,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.17.48
+      '@types/node': 22.15.19
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)':
@@ -16035,6 +16059,10 @@ snapshots:
     dependencies:
       pngjs: 6.0.0
 
+  pixelmatch@7.1.0:
+    dependencies:
+      pngjs: 7.0.0
+
   pkg-types@1.2.1:
     dependencies:
       confbox: 0.1.8
@@ -16066,6 +16094,8 @@ snapshots:
   pngjs@3.4.0: {}
 
   pngjs@6.0.0: {}
+
+  pngjs@7.0.0: {}
 
   pnpm-workspace-yaml@0.3.1:
     dependencies:


### PR DESCRIPTION
### Description

This PR introduces **initial support for Visual Regression Testing** for Vitest via a new `toMatchScreenshot` assertion.

**Related issue**: #6265

In this initial iteration:

- The feature supports PNG screenshots and uses `pixelmatch` as the comparator.
- The architecture is extensible: new comparators or codecs can be added easily, as long as they implement the expected interface.
- Comparators and codecs can be asynchronous.
- Screenshot comparison is executed in Node as a browser command, which allows for future adoption of native codecs or comparators.

The logic to get a stable screenshot follows Playwright's approach (with some differences):

1. Uses as baseline an optional reference screenshot or captures a new screenshot.
2. Takes a screenshot and compares it to the baseline.
3. If they match, the page is considered stable and the function returns.
4. If not, it continues with the latest screenshot as the baseline.
5. Repeats until stability is reached or a timeout is hit.

The command has 6 possible outcomes:

| Outcome | Description | Result |
| :------ | :---------- | :----: |
| `#01` | couldn't get a stable screenshot within timeout | `fail` |
| `#02` | stable screenshot taken, but no reference exists and update is not allowed | `fail` |
| `#03` | stable screenshot taken, no reference exists, but updates are allowed | `fail` |
| `#04` | stable screenshot taken on first try and matches reference | `pass` |
| `#05` | stable screenshot taken matches reference after retries | `pass` |
| `#06` | stable screenshot taken doesn't match reference (fallback case) | `fail` |

The client matcher expects an `Element` or `Locator` along with:

- An optional name for the screenshot
- An optional options object that includes:
  - Screenshot options, excluding conflicting ones
  - Comparator name and options
  - Timeout value

#### To-do
- Fix screenshot paths and naming
- Add config for diff output location
- Support thresholds in `pixelmatch` comparator
- Add documentation
- Write test cases

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
